### PR TITLE
Reorder history on selected prompts

### DIFF
--- a/ctrl/controller.go
+++ b/ctrl/controller.go
@@ -48,7 +48,18 @@ func (c *Controller) LoadHistory() []HistoryEntry {
 	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
 		entries[i], entries[j] = entries[j], entries[i]
 	}
-	return entries
+
+	// Remove duplicates, keeping the most recent entry.
+	seen := make(map[HistoryEntry]bool)
+	var result []HistoryEntry
+	for _, entry := range entries {
+		if !seen[entry] {
+			result = append(result, entry)
+			seen[entry] = true
+		}
+	}
+
+	return result
 }
 
 func (c *Controller) UpdateHistory(prompt, command string) error {

--- a/ctrl/controller_test.go
+++ b/ctrl/controller_test.go
@@ -1,0 +1,40 @@
+package ctrl
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadHistory(t *testing.T) {
+	// Create a temporary history file
+	historyPath := filepath.Join(t.TempDir(), "history.jsonl")
+
+	// Write some history entries with duplicates
+	entries := []HistoryEntry{
+		{Prompt: "p1", Command: "c1"},
+		{Prompt: "p2", Command: "c2"},
+		{Prompt: "p1", Command: "c1"}, // Duplicate
+		{Prompt: "p3", Command: "c3"},
+	}
+
+	// Create a controller and write the entries to the history file
+	controller := &Controller{historyPath: historyPath}
+	for _, entry := range entries {
+		err := controller.UpdateHistory(entry.Prompt, entry.Command)
+		require.NoError(t, err)
+	}
+
+	// Load the history
+	loadedEntries := controller.LoadHistory()
+
+	// Check that duplicates are removed and the order is correct
+	expectedEntries := []HistoryEntry{
+		{Prompt: "p3", Command: "c3"},
+		{Prompt: "p1", Command: "c1"},
+		{Prompt: "p2", Command: "c2"},
+	}
+	assert.Equal(t, expectedEntries, loadedEntries)
+}

--- a/ui/model.go
+++ b/ui/model.go
@@ -224,9 +224,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 				return m, cmd
 			}
 			// User selected an existing command
-			m.selected = selected.Command
-			m.state = stateSelected
-			return m, tea.Quit
+			cmd := m.selectCommand(selected.Prompt, selected.Command)
+			return m, cmd
 
 		case stateSelecting:
 			// User selected a command from the list

--- a/ui/prompt.go
+++ b/ui/prompt.go
@@ -97,7 +97,7 @@ func (m promptModel) ShortHelp() []key.Binding {
 func (m promptModel) Selected() inputPrompt {
 	if selectedItem := m.list.SelectedItem(); selectedItem != nil {
 		he := selectedItem.(historyEntry)
-		return inputPrompt{Command: he.Command}
+		return inputPrompt{Prompt: he.Prompt, Command: he.Command}
 	}
 	// User typed a new command
 	return inputPrompt{Prompt: m.textInput.Value()}


### PR DESCRIPTION
When prompt results are selected from history, we should still save them and reorder history accordingly.